### PR TITLE
upgrade activesupport to 8.0

### DIFF
--- a/lib/rocket_reach/version.rb
+++ b/lib/rocket_reach/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RocketReach
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/rocket_reach.gemspec
+++ b/rocket_reach.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/rocket_reach/version"
 Gem::Specification.new do |spec|
   spec.name          = "rocket-reach"
   spec.version       = RocketReach::VERSION
-  spec.authors       = ["bapu sethi"]
-  spec.email         = ["bapu@nexl.io"]
+  spec.authors       = ["bapu sethi", "Connor Moot"]
+  spec.email         = ["bapu@nexl.io", "connor@nexl.cloud"]
 
   spec.summary       = "Ruby client for connecting to Rocket Reach"
   spec.description   = "Ruby client for connecting to Rocket Reach"
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "activesupport", ">= 4.1.0", "< 8.0"
+  spec.add_dependency "activesupport", ">= 4.1.0", "< 9.0"
   spec.add_dependency "faraday", ">= 1.0.0", "< 3.0"
   spec.add_dependency "multi_json", ">= 1.4.0", "< 2.0"
 


### PR DESCRIPTION
**Summary:**
When trying to upgrade to rails 8.0 in nexl360 I am getting the following error

`Because rails >= 8.0.0, < 8.0.0.1 depends on activesupport = 8.0.0
  and rails >= 8.0.0.1, < 8.0.1 depends on activesupport = 8.0.0.1,
  rails >= 8.0.0, < 8.0.1 requires activesupport = 8.0.0 OR = 8.0.0.1.
And because rails >= 8.0.1, < 8.0.2 depends on activesupport = 8.0.1,
  rails >= 8.0.0, < 8.0.2 requires activesupport = 8.0.0 OR = 8.0.0.1 OR = 8.0.1.
And because rails >= 8.0.2 depends on activesupport = 8.0.2
  and every version of rocket-reach depends on activesupport >= 4.1.0, < 8.0,
  every version of rocket-reach is incompatible with rails >= 8.0.0.
So, because Gemfile depends on rails ~> 8.0.0
  and Gemfile depends on rocket-reach >= 0,
  version solving has failed.`

**Changes:**
- Upgrade activesupport ~> 8

